### PR TITLE
Implement Configuration Fragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
 
         <service android:name=".AlarmService" />
         <service android:name=".RestartAlarmService" />
+        <service android:name=".NotificationService"/>
 
         <activity
             android:name=".AppInfoActivity"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,9 @@
         <service android:name=".RestartAlarmService" />
 
         <activity
+            android:name=".AppInfoActivity"/>
+
+        <activity
             android:name=".GoodMorningActivity"
             android:launchMode="singleTop" />
         <activity

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmYouNeedApplication.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmYouNeedApplication.kt
@@ -9,12 +9,8 @@ class AlarmYouNeedApplication : Application() {
         super.onCreate()
         Realm.init(this)
         Log.d("DEBUGGING LOG", "AlarmYouNeedApplication")
+
+        Thread.sleep(1500)
+        setTheme(R.style.AppTheme)
     }
-
 }
-
-/* Todo List
-* - 활성화 알람 시간 순 정렬
-* - ARCore, Sceneform 버전 확인해보자... 사용중인 버전 성능이 안 좋다
-*
-* */

--- a/app/src/main/java/com/alarm/alARm_you_need/AppInfoActivity.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AppInfoActivity.kt
@@ -1,0 +1,24 @@
+package com.alarm.alARm_you_need
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_app_info.*
+
+class AppInfoActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_app_info)
+
+        val appVersion = "Ver ${packageManager.getPackageInfo(packageName,0).versionName}"
+        app_version.text = appVersion
+
+        btn_suggestion.setOnClickListener {
+
+        }
+
+        btn_show_license.setOnClickListener {
+
+        }
+    }
+}

--- a/app/src/main/java/com/alarm/alARm_you_need/BaseRingActivity.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/BaseRingActivity.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 
 open class BaseRingActivity : AppCompatActivity() {
@@ -16,6 +17,11 @@ open class BaseRingActivity : AppCompatActivity() {
         Log.d("DEBUGGING LOG", "BaseRingActivity::onCreate is called")
         super.onCreate(savedInstanceState)
         alarmId = intent.getStringExtra("ALARM_ID")
+
+        window.decorView.systemUiVisibility =
+            (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_FULLSCREEN)
     }
 
     open fun alarmRingOff() {

--- a/app/src/main/java/com/alarm/alARm_you_need/CloseAppDialog.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/CloseAppDialog.kt
@@ -1,25 +1,31 @@
 package com.alarm.alARm_you_need
 
-import android.app.Dialog
-import android.content.Context
 import android.os.Bundle
-import android.widget.TextView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import kotlinx.android.synthetic.main.close_app_dialog.*
 
-class CloseAppDialog constructor(context: Context) : Dialog(context) {
+class CloseAppDialog: DialogFragment() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.close_app_dialog, container, false)
+    }
 
-        val closeBtn = findViewById<TextView>(R.id.close_app_btn)
-        val cancelBtn = findViewById<TextView>(R.id.close_app_cancel_btn)
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
 
-        closeBtn.setOnClickListener {
-            android.os.Process.killProcess(android.os.Process.myPid())
+        close_app_btn.setOnClickListener {
+            (activity as MainActivity).finish()
         }
 
-        cancelBtn.setOnClickListener {
+        close_app_cancel_btn.setOnClickListener {
             dismiss()
         }
     }
-
 }

--- a/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
@@ -32,8 +32,8 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
     @Override
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
         Log.d("DEBUGGING LOG", "onPreferenceTreeClick()")
-        if (preference.key == "status_bar_noti") {
-            Toast.makeText(requireContext(), "아직 미구현 기능입니다", Toast.LENGTH_SHORT).show()
+        if (preference.key == "pref_status_bar_notification") {
+            Toast.makeText(requireContext(), "업데이트 예정입니다.", Toast.LENGTH_SHORT).show()
             /* todo : 앱과 함께 꺼지지 않도록 구현
             if (bStatusbarnotiswtich) {
                 Log.d("DEBUGGING LOG", "show noti")
@@ -46,9 +46,15 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
             }
              */
         }
-        else if (preference.key == "disturb_mode") {
+        else if (preference.key == "pref_disturb_mode") {
             requireContext().startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
         }
+        else if (preference.key == "pref_onboarding") {
+            val onboardingIntent = Intent(requireContext(), OnboardingActivity::class.java)
+            onboardingIntent.putExtra("isReview", true)
+            requireContext().startActivity(onboardingIntent)
+        }
+
         return super.onPreferenceTreeClick(preference)
     }
 

--- a/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
@@ -47,12 +47,16 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
              */
         }
         else if (preference.key == "pref_disturb_mode") {
-            requireContext().startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
         }
         else if (preference.key == "pref_onboarding") {
             val onboardingIntent = Intent(requireContext(), OnboardingActivity::class.java)
             onboardingIntent.putExtra("isReview", true)
-            requireContext().startActivity(onboardingIntent)
+            startActivity(onboardingIntent)
+        }
+        else if (preference.key == "pref_app_info") {
+            val appInfoIntent = Intent(requireContext(), AppInfoActivity::class.java)
+            startActivity(appInfoIntent)
         }
 
         return super.onPreferenceTreeClick(preference)

--- a/app/src/main/java/com/alarm/alARm_you_need/MainActivity.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/MainActivity.kt
@@ -16,7 +16,7 @@ import kotlinx.android.synthetic.main.activity_main.*
 class MainActivity : AppCompatActivity() {
 
     private var viewModel: ListViewModel? = null
-    private val overlayPermissionResultCode = 1111
+    private val overlayPermissionResultCode = 1
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d("DEBUGGING LOG", "MainActivity::onCreate() is called")
@@ -66,9 +66,8 @@ class MainActivity : AppCompatActivity() {
 
     @Override
     override fun onBackPressed() {
-        val closeAppDialog = CloseAppDialog(this)
-        closeAppDialog.setContentView(R.layout.close_app_dialog)
-        closeAppDialog.show()
+        val closeAppDialog = CloseAppDialog()
+        closeAppDialog.show(supportFragmentManager, "CloseDialog")
     }
 
     private fun requestPermissions() {
@@ -100,10 +99,8 @@ class MainActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == overlayPermissionResultCode) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (!Settings.canDrawOverlays(this)) {
-                    Toast.makeText(this, "권한을 수락해주세요", Toast.LENGTH_SHORT).show()
-                }
+            if (!Settings.canDrawOverlays(this)) {
+                Toast.makeText(this, "권한을 수락해주세요", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/alarm/alARm_you_need/NotificationService.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/NotificationService.kt
@@ -1,0 +1,35 @@
+package com.alarm.alARm_you_need
+
+import android.app.*
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+class NotificationService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "다음 알람"
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("AR람")
+            .setContentText("다음 알람은 시 분 후에 울립니다.")
+            .setSmallIcon(R.mipmap.alarm_you_need_icon)
+            .setContentIntent(pendingIntent)
+            .setVibrate(longArrayOf(0))
+            .build()
+
+        startForeground(1, notification)
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent): IBinder? {
+        return null
+    }
+
+}

--- a/app/src/main/java/com/alarm/alARm_you_need/OnboardingActivity.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/OnboardingActivity.kt
@@ -15,16 +15,13 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val isReview = intent.getBooleanExtra("isReview", false)
-        if (restorePreferenceData() && !isReview) {
+        if (isOnboardingOpenedBefore() && !isReview) {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()
         }
 
-        Thread.sleep(1500)
-        setTheme(R.style.AppTheme)
         super.onCreate(savedInstanceState)
-
         setContentView(R.layout.activity_onboarding)
 
         val list = ArrayList<ScreenItem>()
@@ -68,23 +65,26 @@ class OnboardingActivity : AppCompatActivity() {
         })
 
         btn_get_started.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
+            if (isReview)
+                onBackPressed()
+            else {
+                val intent = Intent(this, MainActivity::class.java)
+                startActivity(intent)
+                saveIsOnboardingOpenedBeforeTrue()
+            }
 
-            savePreferenceData()
         }
     }
 
-    private fun restorePreferenceData(): Boolean {
+    private fun isOnboardingOpenedBefore(): Boolean {
         val sharedPreference = applicationContext.getSharedPreferences("onboardingPref", Context.MODE_PRIVATE)
-
-        return sharedPreference.getBoolean("isOnboardingOpened", false)
+        return sharedPreference.getBoolean("isOnboardingOpenedBefore", false)
     }
 
-    private fun savePreferenceData() {
+    private fun saveIsOnboardingOpenedBeforeTrue() {
         val sharedPreference = applicationContext.getSharedPreferences("onboardingPref", Context.MODE_PRIVATE)
         val editor = sharedPreference.edit()
-        editor.putBoolean("isOnboardingOpened", true)
+        editor.putBoolean("isOnboardingOpenedBefore", true)
         editor.apply()
     }
 

--- a/app/src/main/java/com/alarm/alARm_you_need/OnboardingActivity.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/OnboardingActivity.kt
@@ -14,7 +14,8 @@ import kotlinx.android.synthetic.main.activity_onboarding.*
 class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        if (restorePreferenceData()) {
+        val isReview = intent.getBooleanExtra("isReview", false)
+        if (restorePreferenceData() && !isReview) {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()

--- a/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
@@ -1,8 +1,11 @@
 package com.alarm.alARm_you_need
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import io.realm.Realm
 
@@ -11,6 +14,11 @@ class RebootReceiver : BroadcastReceiver(){
     @Override
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("DEBUGGING LOG", "RebootReceiver::onReceive()")
+        registerActiveAlarms(context)
+        showNotificationIfActive(context)
+    }
+
+    private fun registerActiveAlarms(context: Context) {
         val realm = Realm.getDefaultInstance()
         val activeAlarms = AlarmDao(realm).getActiveAlarms()
 
@@ -20,4 +28,38 @@ class RebootReceiver : BroadcastReceiver(){
             }
         }
     }
+
+    private fun showNotificationIfActive(context: Context) {
+        if (isStatusbarNotificationSwtichOn(context)) {
+            createNotificationChannel(context)
+            startNotificationService(context)
+        }
+    }
+
+    private fun isStatusbarNotificationSwtichOn(context: Context): Boolean {
+        val sharedPreference = context.getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
+        return sharedPreference.getBoolean("isNotifying", false)
+    }
+
+    private fun startNotificationService(context: Context) {
+        val notificationIntent = Intent(context, NotificationService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(notificationIntent)
+        } else {
+            context.startService(notificationIntent)
+        }
+    }
+
+    private fun createNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationChannel = NotificationChannel(
+                NotificationService.CHANNEL_ID,
+                "Notification Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val notificationManager = context.getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(notificationChannel)
+        }
+    }
+
 }

--- a/app/src/main/java/com/alarm/alARm_you_need/RestartAlarmService.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/RestartAlarmService.kt
@@ -25,9 +25,6 @@ class RestartAlarmService : Service() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         Log.d("DEBUGGING LOG", "RestartAlarmService::onStartCommand()")
         val builder = NotificationCompat.Builder(this, "default")
-        builder.setSmallIcon(R.mipmap.ic_launcher)
-        builder.setContentTitle(null)
-        builder.setContentText(null)
 
         Log.d("DEBUGGING LOG", "RESTART!")
         val notificationIntent = Intent(this, MainActivity::class.java)
@@ -38,8 +35,8 @@ class RestartAlarmService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             manager.createNotificationChannel(
                 NotificationChannel(
-                    "default",
-                    "기본 채널",
+                    "",
+                    "기타",
                     NotificationManager.IMPORTANCE_NONE
                 )
             )

--- a/app/src/main/res/layout/activity_app_info.xml
+++ b/app/src/main/res/layout/activity_app_info.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="#EEEEEE"
+    tools:context=".AppInfoActivity">
+
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/app_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.893"
+        app:srcCompat="@mipmap/alarm_you_need_icon" />
+
+    <TextView
+        android:id="@+id/app_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="casual"
+        android:text="alARm you need"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/app_version"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/app_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:fontFamily="casual"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/guideline2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/btn_suggestion"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
+        android:text="의견 남기기"
+        android:textSize="16sp"
+        android:background="@drawable/btn_gradient_selector"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline2" />
+
+    <Button
+        android:id="@+id/btn_show_license"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:textSize="16sp"
+        android:text="오픈소스 라이센스"
+        android:background="@drawable/btn_gradient_selector"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_suggestion" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="422dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,11 +11,12 @@
     <string name="normal_header">일반</string>
 
     <!-- Messages Preferences -->
-    <string name="status_bar_title">상단바 알림</string>
-    <string name="disturb_mode_title">방해금지모드에서도 알람 허용</string>
-
-    <!-- normal Preferences -->
-    <string name="language_title">언어 설정</string>
+    <string name="pref_status_bar_notification_title">상단바 알림</string>
+    <string name="pref_status_bar_notification_summary">상단바에 다음 알람시간을 표시합니다.</string>
+    <string name="pref_disturb_mode_title">방해금지모드에서도 알람 허용</string>
+    <string name="pref_disturb_mode_summary">방해금지모드에서도 알람이 울립니다</string>
+    <string name="pref_onboarding_title">AR 도움말 다시보기</string>
+    <string name="pref_app_info_title">앱 정보</string>
 
     <!-- onBoarding Messages -->
     <string name="onboarding1_title">준비 - 스캐너</string>
@@ -41,18 +42,6 @@
         2.미로가 생성되지 않으면 알람을 끌 수 없으니.\n  꼭 프리뷰를 확인하세요!\n\n
         [Tip] 해당 이미지를 침실에서 멀리 두세요</string>
 
-    <!--hello ar property-->
-    <string name="depth_use_explanation" translatable="false">When Depth is enabled on supported devices, virtual objects adapt to the environment by blending in with the real world.</string>
-    <string name="button_text_enable_depth" translatable="false">Enable</string>
-    <string name="button_text_disable_depth" translatable="false">Disable</string>
-    <string name="options_title_with_depth" translatable="false">Your device supports depth</string>
-    <string name="options_title_without_depth" translatable="false">Your device does not support depth</string>
-    <string name="done" translatable="false">Done</string>
-    <string-array name="depth_options_array" translatable="false">
-        <item>Enable depth</item>
-        <item>Show depth map</item>
-
-    </string-array>
 
     <string name="fit_image_to_scan">Fit image to scan</string>
 

--- a/app/src/main/res/xml/preferences_setting.xml
+++ b/app/src/main/res/xml/preferences_setting.xml
@@ -1,32 +1,33 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory app:title="@string/alarm_header">
 
         <SwitchPreference
-            app:key="status_bar_noti"
-            app:title="@string/status_bar_title"
+            app:key="pref_status_bar_notification"
+            app:title="@string/pref_status_bar_notification_title"
+            app:summary="@string/pref_status_bar_notification_summary"
             app:useSimpleSummaryProvider="true" />
 
         <Preference
-            app:key="disturb_mode"
-            app:title="@string/disturb_mode_title"
-            app:summaryOff="진동, 무음에서 벨소리가 울리지 않습니다"
-            app:summaryOn="진동, 무음에서도 벨소리가 울립니다"
+            app:key="pref_disturb_mode"
+            app:title="@string/pref_disturb_mode_title"
+            app:summary="@string/pref_disturb_mode_summary"
             app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/normal_header">
-        <!--
-        @TODO : language support
-        <ListPreference
-            app:key="language"
-            app:title="@string/language_title"
-            app:defaultValue="Korean"
-            app:entries="@array/language_entries"
-            app:entryValues="@array/language_values" />
-        -->
+
+        <Preference
+            app:key="pref_onboarding"
+            app:title="@string/pref_onboarding_title"/>
+
+
+        <Preference
+            app:key="pref_app_info"
+            app:title="@string/pref_app_info_title"/>
+
     </PreferenceCategory>
 
 


### PR DESCRIPTION
# todo1: 상단바 notification 서비스 구현
> Foreground 서비스로 앱과 함께 꺼지지 않도록 구현
  별도의 스레드는 사용하지 않음

# todo2: onboardingActivity 다시보기 구현
> intent에 review 여부를 전달하여 onboardingActivity::onCreate()에서 체크함

## TBD
> notification에 다음 알람까지 남은 시간을 계산해서 보여주어야 한다
    AlarmTool의 리팩토링이 필요하다고 판단 된다