### PR TITLE
다음 알람까지 남은시간 구현

### DIFF
--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmListFragment.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmListFragment.kt
@@ -1,4 +1,5 @@
 package com.alarm.alARm_you_need
+
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -12,7 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.fragment_alarm_list.*
 
-class AlarmListFragment: Fragment(){
+class AlarmListFragment : Fragment() {
     private lateinit var listAdapter: AlarmListAdapter
     private var viewModel: ListViewModel? = null
 
@@ -20,24 +21,25 @@ class AlarmListFragment: Fragment(){
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_alarm_list, container, false)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        
+
         viewModel = requireActivity().application!!.let {
             ViewModelProvider(
                 requireActivity().viewModelStore,
-                ViewModelProvider.AndroidViewModelFactory(it))
+                ViewModelProvider.AndroidViewModelFactory(it)
+            )
                 .get(ListViewModel::class.java)
         }
 
         viewModel!!.let {
             it.alarmLiveData.value?.let {
                 listAdapter = AlarmListAdapter(it)
-                alarmListView.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+                alarmListView.layoutManager =
+                    LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
                 alarmListView.adapter = listAdapter
                 listAdapter.itemClickListener = {
                     val intent = Intent(activity, AlarmSettingActivity::class.java)
@@ -48,6 +50,7 @@ class AlarmListFragment: Fragment(){
 
                 listAdapter.checkBoxClickListener = {
                     viewModel!!.toggleAlarm(it)
+                    AlarmTool.updateAlarmNotification(requireContext())
                 }
 
             }

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
@@ -1,5 +1,8 @@
 package com.alarm.alARm_you_need
+
 import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -10,10 +13,15 @@ import android.util.Log
 import io.realm.Realm
 import java.util.*
 
-class AlarmTool: BroadcastReceiver() {
-    companion object
-    {
-        private const val ACTION_RUN_ALARM = "RUN_ALARM"
+class AlarmTool : BroadcastReceiver() {
+
+    companion object {
+        const val CHANNEL_ID = "다음 알람"
+        const val ACTION_RUN_ALARM = "RUN_ALARM"
+        const val DAY_OF_WEEK_BASE = 4
+        ////1970.01.01 == Thursday
+
+        private val DAY_OF_WEEK = arrayOf("일", "월", "화", "수", "목", "금", "토")
 
         private fun createAlarmIntent(context: Context, id: String): PendingIntent {
             Log.d("DEBUGGING LOG", "AlarmTool::createAlarmIntent() is called ... id : $id")
@@ -27,11 +35,24 @@ class AlarmTool: BroadcastReceiver() {
 
         fun addAlarm(context: Context, id: String, hourOfDay: Int, minute: Int) {
             Log.d("DEBUGGING LOG", "AlarmTool::addAlarm() is called ... $hourOfDay:$minute")
-
             val alarmIntent = createAlarmIntent(context, id)
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                getTriggerAtMillis(hourOfDay, minute),
+                alarmIntent
+            )
 
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, getTriggerAtMillis(hourOfDay, minute), alarmIntent)
+            updateAlarmNotification(context)
+        }
+
+        fun deleteAlarm(context: Context, id: String) {
+            Log.d("DEBUGGING LOG", "AlarmTool::deleteAlarm() is called  ...id : $id")
+            val alarmIntent = createAlarmIntent(context, id)
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            alarmManager.cancel(alarmIntent)
+
+            updateAlarmNotification(context)
         }
 
         private fun getTriggerAtMillis(hourOfDay: Int, minute: Int): Long {
@@ -45,7 +66,7 @@ class AlarmTool: BroadcastReceiver() {
                 getTimeInMillis(true, hourOfDay, minute)
         }
 
-        fun getTimeInMillis(tomorrow: Boolean, hourOfDay: Int, minute: Int): Long {
+        private fun getTimeInMillis(tomorrow: Boolean, hourOfDay: Int, minute: Int): Long {
             val calendar = GregorianCalendar.getInstance() as GregorianCalendar
             if (tomorrow) calendar.add(GregorianCalendar.DAY_OF_YEAR, 1)
             calendar[GregorianCalendar.HOUR_OF_DAY] = hourOfDay
@@ -55,32 +76,182 @@ class AlarmTool: BroadcastReceiver() {
             return calendar.timeInMillis
         }
 
-        fun deleteAlarm(context: Context, id: String) {
-            Log.d("AlarmTool::deleteAlarm", "id :$id")
-            Log.d("DEBUGGING LOG", "AlarmTool::deleteAlarm() is called  ...id : $id")
-            val alarmIntent = createAlarmIntent(context, id)
-            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            alarmManager.cancel(alarmIntent)
+        fun updateAlarmNotification(context: Context) {
+            createNotificationChannel(context)
+            val notificationIntent = Intent(context, NotificationService::class.java)
+            val timeOfUpcomingAlarm = findTimeOfUpcomingAlarm(false)
+
+            notificationIntent.putExtra("upcomingTime", timeOfUpcomingAlarm)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val sharedPreference =
+                    context.getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
+                val isNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
+                if (isNotificationSwitchOn)
+                    context.startForegroundService(notificationIntent)
+            }
+        }
+
+        private fun findTimeOfUpcomingAlarm(isRemainTime: Boolean): Long {
+            val realm = Realm.getDefaultInstance()
+            val alarmData = AlarmDao(realm).getActiveAlarms()
+            var upcomingTime: Long = Long.MAX_VALUE
+
+            if (alarmData != null) {
+                for (alarm in alarmData) {
+                    val remainTime = findTimeOfAlarm(
+                        getTargetDays(alarm),
+                        alarm.hour,
+                        alarm.minute,
+                        isRemainTime
+                    )
+                    if (remainTime < upcomingTime) {
+                        upcomingTime = remainTime
+                    }
+                }
+            }
+
+            return upcomingTime
+        }
+
+        fun findTimeOfAlarm(
+            targetDays: BooleanArray,
+            targetHour: Int,
+            targetMinute: Int,
+            isRemainTime: Boolean
+        ): Long {
+            var targetTimeInMillis = getTimeInMillis(false, targetHour, targetMinute)
+            val currentTime = GregorianCalendar.getInstance() as GregorianCalendar
+            val currentTimeInMillis = currentTime.timeInMillis
+            val dayOfToday = currentTime.get(GregorianCalendar.DAY_OF_WEEK) - 1
+
+            val dDay = getDayOffsetFromToday(
+                currentTimeInMillis,
+                targetTimeInMillis,
+                dayOfToday,
+                targetDays
+            )
+            if (dDay == Int.MAX_VALUE)
+                return Long.MAX_VALUE
+
+            targetTimeInMillis += (dDay * 1000 * 60 * 60 * 24)
+
+            return if (isRemainTime)
+                targetTimeInMillis - currentTimeInMillis
+            else
+                targetTimeInMillis
+        }
+
+        private fun getDayOffsetFromToday(
+            sourceTimeInMillis: Long, targetTimeInMillis: Long,
+            dayOfToday: Int, targetDays: BooleanArray
+        ): Int {
+            var dDay = 0
+            var dayOffset = dayOfToday
+            if (targetTimeInMillis < sourceTimeInMillis) {
+                dayOffset++
+                dDay++
+            }
+            dayOffset %= 7
+
+            while (!targetDays[dayOffset]) {
+                dayOffset++
+                dayOffset %= 7
+                dDay++
+                if (dDay > 10)
+                    return Int.MAX_VALUE
+            }
+
+            return dDay
+        }
+
+        fun convertMillisToTimeFormat(timeInMillis: Long): String {
+            val minute = (timeInMillis / (1000 * 60)) % 60
+            val hour = (timeInMillis / (1000 * 60 * 60)) % 24
+            val day = (timeInMillis / (1000 * 60 * 60)) / 24 + DAY_OF_WEEK_BASE
+
+            return if (timeInMillis == Long.MAX_VALUE) "등록된 알람이 없습니다."
+            else String.format(
+                "[%s] %d 시 %d 분에 알람이 울립니다.",
+                DAY_OF_WEEK[day.toInt() % 7],
+                hour,
+                minute
+            )
+        }
+
+        fun convertMillisToRemainingTimeFormat(timeInMillis: Long): String {
+            val minute = (timeInMillis / (1000 * 60)) % 60
+            val hour = (timeInMillis / (1000 * 60 * 60)) % 24
+            val day = (timeInMillis / (1000 * 60 * 60)) / 24
+
+            if (timeInMillis == Long.MAX_VALUE) return ""
+
+            return String.format("%d 일 %d시간 %d분 후에 알람이 울립니다.", day, hour, minute)
+        }
+
+        private fun getTargetDays(alarm: AlarmData): BooleanArray {
+            val targetDays = BooleanArray(7)
+            if (alarm.sun) targetDays[0] = true
+            if (alarm.mon) targetDays[1] = true
+            if (alarm.tue) targetDays[2] = true
+            if (alarm.wed) targetDays[3] = true
+            if (alarm.thur) targetDays[4] = true
+            if (alarm.fri) targetDays[5] = true
+            if (alarm.sat) targetDays[6] = true
+
+            return targetDays
+        }
+
+        private fun createNotificationChannel(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val notificationChannel = NotificationChannel(
+                    CHANNEL_ID,
+                    "Notification Service Channel",
+                    NotificationManager.IMPORTANCE_NONE
+                )
+                val notificationManager = context.getSystemService(NotificationManager::class.java)
+                notificationManager.createNotificationChannel(notificationChannel)
+            }
+        }
+
+        private fun deleteNotificationChannel(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val notificationManager = context.getSystemService(NotificationManager::class.java)
+                notificationManager.deleteNotificationChannel(CHANNEL_ID)
+            }
+
+        }
+
+        fun showUpcomingAlarmNotification(context: Context) {
+            updateAlarmNotification(context)
+        }
+
+        fun hideUpcomingAlarmNotification(context: Context) {
+            val notificationIntent = Intent(context, NotificationService::class.java)
+            context.stopService(notificationIntent)
+
+            deleteNotificationChannel(context)
         }
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        when(intent.action) {
+        when (intent.action) {
             ACTION_RUN_ALARM -> {
                 if (AlarmService.service != null) return;
                 val alarmId: String? = intent.getStringExtra("ALARM_ID")
                 val realm = Realm.getDefaultInstance()
                 val alarmData = AlarmDao(realm).selectAlarm(alarmId!!)
-                Log.d("DEBUGGING LOG",
+                Log.d(
+                    "DEBUGGING LOG",
                     "[Received ACTION_RUN_ALARM info]" +
-                            " alarm Id : $alarmId"+
+                            " alarm Id : $alarmId" +
                             " is today? : " + isAlarmToday(alarmData) +
-                            " is active? : " + alarmData.active)
+                            " is active? : " + alarmData.active
+                )
 
                 if (isAlarmToday(alarmData) && alarmData.active) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         val serviceIntent = Intent(context, RestartAlarmService::class.java)
-                        serviceIntent.putExtra("ALARM_ID",alarmId)
+                        serviceIntent.putExtra("ALARM_ID", alarmId)
                         context.startForegroundService(serviceIntent)
                     } else {
                         val serviceIntent = Intent(context, AlarmService::class.java)
@@ -99,11 +270,12 @@ class AlarmTool: BroadcastReceiver() {
             }
         }
 
+
     }
 
     private fun isAlarmToday(alarmData: AlarmData): Boolean {
         val calendar = GregorianCalendar.getInstance() as GregorianCalendar
-        return when (calendar[GregorianCalendar.DAY_OF_WEEK]){
+        return when (calendar[GregorianCalendar.DAY_OF_WEEK]) {
             GregorianCalendar.SUNDAY -> alarmData.sun
             GregorianCalendar.MONDAY -> alarmData.mon
             GregorianCalendar.TUESDAY -> alarmData.tue
@@ -113,4 +285,5 @@ class AlarmTool: BroadcastReceiver() {
             else -> alarmData.sat
         }
     }
+
 }

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
@@ -25,9 +25,6 @@ class AlarmTool: BroadcastReceiver() {
             return PendingIntent.getBroadcast(context, 0, intent, 0)
         }
 
-        /*todo 현재는 (h, m)만 보고 24시간 내에 얼마나 남았는지 계산해서 브로드캐스팅하고
-        *  onReceive에서 오늘에 해당하는 알람인지 확인함. 이것을 d 정보도 넘겨서 깔끔히 처리하자*/
-
         fun addAlarm(context: Context, id: String, hourOfDay: Int, minute: Int) {
             Log.d("DEBUGGING LOG", "AlarmTool::addAlarm() is called ... $hourOfDay:$minute")
 
@@ -98,18 +95,6 @@ class AlarmTool: BroadcastReceiver() {
                     ringIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     ringIntent.putExtra("ALARM_ID", alarmId)
                     context.startActivity(ringIntent)
-                }
-            }
-
-            Intent.ACTION_BOOT_COMPLETED -> {
-                Log.d("DEBUGGING LOG", "AlarmTool::onReceive() ... ACTION_BOOT_COMPLETED")
-                val realm = Realm.getDefaultInstance()
-                val activeAlarms = AlarmDao(realm).getActiveAlarms()
-
-                if (activeAlarms != null) {
-                    for (alarmData in activeAlarms) {
-                        addAlarm(context, alarmData.alarmId, alarmData.hour, alarmData.minute)
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
@@ -1,17 +1,12 @@
 package com.alarm.alARm_you_need
 
-import android.app.*
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.widget.Toast
-import androidx.core.content.ContextCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import com.alarm.alARm_you_need.NotificationService.Companion.CHANNEL_ID
 
 class ConfigurationFragment : PreferenceFragmentCompat() {
 
@@ -23,38 +18,30 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
         Log.d("DEBUGGING LOG", "onPreferenceTreeClick()")
         if (preference.key == "pref_status_bar_notification") {
-            Toast.makeText(requireContext(), "업데이트 예정입니다.", Toast.LENGTH_SHORT).show()
 
-            /*todo : make clean*/
-            val sharedPreference = requireContext().getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
-            val isStatusbarNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
+            val sharedPreference =
+                requireContext().getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
+            val isNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
+            val editor = sharedPreference.edit()
 
-            if (!isStatusbarNotificationSwitchOn) {
+            if (!isNotificationSwitchOn) {
                 Log.d("DEBUGGING LOG", "hide noti")
-                showStatusbarNotification()
-
-                val editor = sharedPreference.edit()
                 editor.putBoolean("isNotifying", true)
                 editor.apply()
+                showNotification()
             } else {
                 Log.d("DEBUGGING LOG", "show noti")
-                hideStatusbarNotification()
-
-                val editor = sharedPreference.edit()
                 editor.putBoolean("isNotifying", false)
                 editor.apply()
+                hideNotification()
             }
-
-        }
-        else if (preference.key == "pref_disturb_mode") {
+        } else if (preference.key == "pref_disturb_mode") {
             startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
-        }
-        else if (preference.key == "pref_onboarding") {
+        } else if (preference.key == "pref_onboarding") {
             val onboardingIntent = Intent(requireContext(), OnboardingActivity::class.java)
             onboardingIntent.putExtra("isReview", true)
             startActivity(onboardingIntent)
-        }
-        else if (preference.key == "pref_app_info") {
+        } else if (preference.key == "pref_app_info") {
             val appInfoIntent = Intent(requireContext(), AppInfoActivity::class.java)
             startActivity(appInfoIntent)
         }
@@ -62,37 +49,14 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
         return super.onPreferenceTreeClick(preference)
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val notificationChannel = NotificationChannel(CHANNEL_ID,
-                "Notification Service Channel",
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-            val notificationManager = requireContext().getSystemService(NotificationManager::class.java)
-            notificationManager.createNotificationChannel(notificationChannel)
-        }
-    }
-
-    private fun deleteNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val notificationManager = requireContext().getSystemService(NotificationManager::class.java)
-            notificationManager.deleteNotificationChannel(CHANNEL_ID)
-        }
-    }
-
-    private fun showStatusbarNotification() {
+    private fun showNotification() {
         Log.d("DEBUGGING LOG", "showStatusNotification")
-        createNotificationChannel()
-        val notificationIntent = Intent(requireContext(), NotificationService::class.java)
-        ContextCompat.startForegroundService(requireContext() , notificationIntent)
+        AlarmTool.showUpcomingAlarmNotification(requireContext())
     }
 
-    private fun hideStatusbarNotification() {
+    private fun hideNotification() {
         Log.d("DEBUGGING LOG", "hideStatusNotification")
-        val notificationIntent = Intent(requireContext(), NotificationService::class.java)
-        requireContext().stopService(notificationIntent)
-
-        deleteNotificationChannel()
+        AlarmTool.hideUpcomingAlarmNotification(requireContext())
     }
 
 }

--- a/app/src/main/java/com/alarm/alARm_you_need/NotificationService.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/NotificationService.kt
@@ -1,30 +1,34 @@
 package com.alarm.alARm_you_need
 
-import android.app.*
+import android.app.PendingIntent
+import android.app.Service
 import android.content.Intent
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 
 class NotificationService : Service() {
 
-    companion object {
-        const val CHANNEL_ID = "다음 알람"
-    }
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val notificationIntent = Intent(this, MainActivity::class.java)
         val pendingIntent =
-            PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            PendingIntent.getActivity(
+                this,
+                0,
+                notificationIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT
+            )
 
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+        val upcomingAlarmInMillis = intent.getLongExtra("upcomingTime", 0L)
+        val notification = NotificationCompat.Builder(this, AlarmTool.CHANNEL_ID)
             .setContentTitle("AR람")
-            .setContentText("다음 알람은 시 분 후에 울립니다.")
+            .setContentText(AlarmTool.convertMillisToTimeFormat(upcomingAlarmInMillis))
             .setSmallIcon(R.mipmap.alarm_you_need_icon)
             .setContentIntent(pendingIntent)
-            .setVibrate(longArrayOf(0))
             .build()
 
         startForeground(1, notification)
+
         return START_STICKY
     }
 

--- a/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
@@ -7,9 +7,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import com.alarm.alARm_you_need.AlarmTool.Companion.CHANNEL_ID
 import io.realm.Realm
 
-class RebootReceiver : BroadcastReceiver(){
+class RebootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("DEBUGGING LOG", "RebootReceiver::onReceive()")
@@ -56,7 +57,7 @@ class RebootReceiver : BroadcastReceiver(){
     private fun createNotificationChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationChannel = NotificationChannel(
-                NotificationService.CHANNEL_ID,
+                CHANNEL_ID,
                 "Notification Service Channel",
                 NotificationManager.IMPORTANCE_DEFAULT
             )

--- a/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
@@ -11,11 +11,14 @@ import io.realm.Realm
 
 class RebootReceiver : BroadcastReceiver(){
 
-    @Override
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("DEBUGGING LOG", "RebootReceiver::onReceive()")
-        registerActiveAlarms(context)
-        showNotificationIfActive(context)
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED -> {
+                registerActiveAlarms(context)
+                showNotificationIfActive(context)
+            }
+        }
     }
 
     private fun registerActiveAlarms(context: Context) {

--- a/app/src/main/java/com/alarm/alARm_you_need/data/AlarmSettingViewModel.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/data/AlarmSettingViewModel.kt
@@ -1,4 +1,5 @@
 package com.alarm.alARm_you_need
+
 import android.content.Context
 import android.media.RingtoneManager
 import android.net.Uri
@@ -7,7 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.realm.Realm
 
-class AlarmSettingViewModel: ViewModel() {
+class AlarmSettingViewModel : ViewModel() {
 
     val remainTime: MutableLiveData<Long> = MutableLiveData<Long>().apply { value = 0 }
     val title: MutableLiveData<String> = MutableLiveData<String>().apply { value = "" }
@@ -24,10 +25,12 @@ class AlarmSettingViewModel: ViewModel() {
     val active: MutableLiveData<Boolean> = MutableLiveData<Boolean>().apply { value = true }
 
     val defaultUriRingtone: Uri? = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
-    var uriRingtone: MutableLiveData<String> = MutableLiveData<String>().apply { value = defaultUriRingtone.toString()}
+    var uriRingtone: MutableLiveData<String> =
+        MutableLiveData<String>().apply { value = defaultUriRingtone.toString() }
     val uriImage: MutableLiveData<String> = MutableLiveData<String>().apply { value = null }
     val volume: MutableLiveData<Int> = MutableLiveData<Int>().apply { value = 50 }
-    val alarmType : MutableLiveData<String> = MutableLiveData<String>().apply {value = AlarmData.TYPE_DEFAULT}
+    val alarmType: MutableLiveData<String> =
+        MutableLiveData<String>().apply { value = AlarmData.TYPE_DEFAULT }
 
     private var alarmData = AlarmData()
 
@@ -67,20 +70,25 @@ class AlarmSettingViewModel: ViewModel() {
         alarmType.value = alarmData.alarmType
     }
 
-    fun addOrUpdateAlarm(context : Context, title: String, hour: Int, minute: Int, apm: String,
-                         sun: Boolean, mon: Boolean, tue: Boolean, wed: Boolean, thur: Boolean,
-                         fri: Boolean, sat: Boolean, active: Boolean, uriRingtone: String,
-                         uriImage: String?, volume: Int, alarmType: String) {
+    fun addOrUpdateAlarm(
+        context: Context, title: String, hour: Int, minute: Int, apm: String,
+        sun: Boolean, mon: Boolean, tue: Boolean, wed: Boolean, thur: Boolean,
+        fri: Boolean, sat: Boolean, active: Boolean, uriRingtone: String,
+        uriImage: String?, volume: Int, alarmType: String
+    ) {
 
-        alarmDao.addOrUpdateAlarm(alarmData, title, hour, minute, apm,
-            sun, mon, tue, wed, thur, fri, sat, active, uriRingtone, uriImage, volume, alarmType)
+        alarmDao.addOrUpdateAlarm(
+            alarmData, title, hour, minute, apm,
+            sun, mon, tue, wed, thur, fri, sat, active, uriRingtone, uriImage, volume, alarmType
+        )
 
         AlarmTool.deleteAlarm(context, alarmData.alarmId)
         AlarmTool.addAlarm(context, alarmData.alarmId, alarmData.hour, alarmData.minute)
     }
 
-    fun deleteAlarm(id: String) {
+    fun deleteAlarm(context: Context, id: String) {
         alarmDao.deleteAlarm(id)
+        AlarmTool.deleteAlarm(context, id)
     }
 
 }

--- a/app/src/main/java/com/alarm/alARm_you_need/data/AlarmSettingViewModel.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/data/AlarmSettingViewModel.kt
@@ -9,6 +9,7 @@ import io.realm.Realm
 
 class AlarmSettingViewModel: ViewModel() {
 
+    val remainTime: MutableLiveData<Long> = MutableLiveData<Long>().apply { value = 0 }
     val title: MutableLiveData<String> = MutableLiveData<String>().apply { value = "" }
     val hour: MutableLiveData<Int> = MutableLiveData<Int>().apply { value = 8 }
     val minute: MutableLiveData<Int> = MutableLiveData<Int>().apply { value = 30 }


### PR DESCRIPTION
- [x] todo1 : Notification에 가장 빠른 알람 표시
- [x] todo2 : AlarmSettingFragment에서 설정한 알람까지 남은시간 계산

- 전적으로 Alarm과 관련된 구현은 AlarmTool에서 처리하도록 구현함
- 가장 빠른 알람은 모든 realm의 active alarmData를 비교해서 가장 빠른 알람으로 설정
   - 이 때, 현재 시각을 빼면 남은 시간 계산 가능.
   - 현재 시각을 안 빼면 해당 알람이 울리는 시각 계산 가능

- AlarmSettingFragment에서는 timepicker와 모든 요일 버튼에 listener를 등록해서 실시간으로 남은시간이 변하도록 함.

