### PR TITLE
Feature/preference 알람 볼륨 설정 버그 수정 및 '언제나 최대 볼륨' 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,7 +94,7 @@
 
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="@string/admob_app_id"/>
+            android:value="@string/admob_app_id_for_test"/>
 
         <meta-data
             android:name="com.google.ar.core"

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmService.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmService.kt
@@ -1,4 +1,5 @@
 package com.alarm.alARm_you_need
+
 import android.app.*
 import android.content.Context
 import android.content.Intent
@@ -9,6 +10,7 @@ import android.os.Build
 import android.os.IBinder
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.provider.MediaStore
 import android.util.Log
 import io.realm.Realm
 import java.util.*
@@ -18,7 +20,8 @@ class AlarmService : Service() {
     private lateinit var vibrator: Vibrator
     private lateinit var alarmId: String
     private val ACTION_RUN_ALARM = "RUN_ALARM"
-    companion object  {
+
+    companion object {
         var service: Intent? = null
         var normalExit: Boolean = false
     }
@@ -31,21 +34,24 @@ class AlarmService : Service() {
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        service = intent
-
         Log.d("DEBUGGING LOG", "AlarmService::onStartCommand() is called")
+
+        service = intent
         alarmId = intent.getStringExtra("ALARM_ID")!!
         val realm = Realm.getDefaultInstance()
         val alarmData = AlarmDao(realm).selectAlarm(alarmId)
-
-        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 15, AudioManager.FLAG_PLAY_SOUND)
-        }
+        val sharedPreferences =
+            getSharedPreferences("configurationPreference", Context.MODE_PRIVATE)
+        val isAlwaysMaxVolumeSet = sharedPreferences.getBoolean("pref_always_max_volume", false)
 
         mediaPlayer = MediaPlayer.create(this, Uri.parse(alarmData.uriRingtone))
         mediaPlayer.setVolume(1.0F * alarmData.volume, 1.0F * alarmData.volume)
         mediaPlayer.isLooping = true
+
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        if (isAlwaysMaxVolumeSet) {
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 15, AudioManager.FLAG_PLAY_SOUND)
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(500, 500), 0))
@@ -67,7 +73,7 @@ class AlarmService : Service() {
         mediaPlayer.release()
         vibrator.cancel()
 
-        if (!normalExit){
+        if (!normalExit) {
             setAlarmTimer()
         }
     }
@@ -83,7 +89,11 @@ class AlarmService : Service() {
         intent.action = ACTION_RUN_ALARM
         val sender = PendingIntent.getBroadcast(this, 0, intent, 0)
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, sender)
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            calendar.timeInMillis,
+            sender
+        )
     }
 }
 

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmService.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmService.kt
@@ -45,12 +45,21 @@ class AlarmService : Service() {
         val isAlwaysMaxVolumeSet = sharedPreferences.getBoolean("pref_always_max_volume", false)
 
         mediaPlayer = MediaPlayer.create(this, Uri.parse(alarmData.uriRingtone))
-        mediaPlayer.setVolume(1.0F * alarmData.volume, 1.0F * alarmData.volume)
         mediaPlayer.isLooping = true
 
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         if (isAlwaysMaxVolumeSet) {
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 15, AudioManager.FLAG_PLAY_SOUND)
+            audioManager.setStreamVolume(
+                AudioManager.STREAM_MUSIC,
+                15,
+                AudioManager.FLAG_PLAY_SOUND
+            )
+        } else {
+            audioManager.setStreamVolume(
+                AudioManager.STREAM_MUSIC,
+                alarmData.volume,
+                AudioManager.FLAG_PLAY_SOUND
+            )
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)

--- a/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/AlarmTool.kt
@@ -84,8 +84,9 @@ class AlarmTool : BroadcastReceiver() {
             notificationIntent.putExtra("upcomingTime", timeOfUpcomingAlarm)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val sharedPreference =
-                    context.getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
-                val isNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
+                    context.getSharedPreferences("configurationPreference", Context.MODE_PRIVATE)
+                val isNotificationSwitchOn =
+                    sharedPreference.getBoolean("pref_status_bar_notification", false)
                 if (isNotificationSwitchOn)
                     context.startForegroundService(notificationIntent)
             }
@@ -97,7 +98,8 @@ class AlarmTool : BroadcastReceiver() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val sharedPreference =
                     context.getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
-                val isNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
+                val isNotificationSwitchOn =
+                    sharedPreference.getBoolean("configurationPreference", false)
                 if (isNotificationSwitchOn)
                     context.stopService(notificationIntent)
             }

--- a/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/ConfigurationFragment.kt
@@ -14,39 +14,53 @@ class ConfigurationFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.preferences_setting, rootKey)
     }
 
-    @Override
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
         Log.d("DEBUGGING LOG", "onPreferenceTreeClick()")
-        if (preference.key == "pref_status_bar_notification") {
-
-            val sharedPreference =
-                requireContext().getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
-            val isNotificationSwitchOn = sharedPreference.getBoolean("isNotifying", false)
-            val editor = sharedPreference.edit()
-
-            if (!isNotificationSwitchOn) {
-                Log.d("DEBUGGING LOG", "hide noti")
-                editor.putBoolean("isNotifying", true)
-                editor.apply()
-                showNotification()
-            } else {
-                Log.d("DEBUGGING LOG", "show noti")
-                editor.putBoolean("isNotifying", false)
-                editor.apply()
-                hideNotification()
+        when (preference.key) {
+            "pref_status_bar_notification", "pref_always_max_volume"-> {
+                toggleSwitchPreference(preference.key)
             }
-        } else if (preference.key == "pref_disturb_mode") {
-            startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
-        } else if (preference.key == "pref_onboarding") {
-            val onboardingIntent = Intent(requireContext(), OnboardingActivity::class.java)
-            onboardingIntent.putExtra("isReview", true)
-            startActivity(onboardingIntent)
-        } else if (preference.key == "pref_app_info") {
-            val appInfoIntent = Intent(requireContext(), AppInfoActivity::class.java)
-            startActivity(appInfoIntent)
+            "pref_disturb_mode"-> {
+                startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
+            }
+            "pref_onboarding"-> {
+                val onboardingIntent = Intent(requireContext(), OnboardingActivity::class.java)
+                onboardingIntent.putExtra("isReview", true)
+                startActivity(onboardingIntent)
+            }
+            "pref_app_info"-> {
+                val appInfoIntent = Intent(requireContext(), AppInfoActivity::class.java)
+                startActivity(appInfoIntent)
+            }
         }
 
         return super.onPreferenceTreeClick(preference)
+    }
+
+    private fun toggleSwitchPreference(key: String) {
+        val sharedPreference =
+            requireContext().getSharedPreferences("configurationPreference", Context.MODE_PRIVATE)
+        val isSwitchOn = sharedPreference.getBoolean(key, false)
+
+        val editor = sharedPreference.edit()
+        editor.putBoolean(key, !isSwitchOn)
+        editor.apply()
+
+        when (key) {
+            "pref_status_bar_notification" -> {
+                toggleNotification(!isSwitchOn)
+            }
+            "pref_always_max_volume" -> {
+                //nothing to do
+            }
+        }
+    }
+
+    private fun toggleNotification(isSwitchOn: Boolean) {
+        if (isSwitchOn)
+            showNotification()
+        else
+            hideNotification()
     }
 
     private fun showNotification() {

--- a/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
+++ b/app/src/main/java/com/alarm/alARm_you_need/RebootReceiver.kt
@@ -40,7 +40,8 @@ class RebootReceiver : BroadcastReceiver() {
     }
 
     private fun isStatusbarNotificationSwtichOn(context: Context): Boolean {
-        val sharedPreference = context.getSharedPreferences("notifyPref", Context.MODE_PRIVATE)
+        val sharedPreference =
+            context.getSharedPreferences("configurationPreference", Context.MODE_PRIVATE)
         return sharedPreference.getBoolean("isNotifying", false)
     }
 

--- a/app/src/main/res/layout/activity_augmented_image.xml
+++ b/app/src/main/res/layout/activity_augmented_image.xml
@@ -57,6 +57,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         ads:adSize="BANNER"
-        ads:adUnitId="@string/admob_banner_unit_id"/>
+        ads:adUnitId="@string/admob_banner_unit_id_for_test"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_default_ring.xml
+++ b/app/src/main/res/layout/activity_default_ring.xml
@@ -26,6 +26,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         ads:adSize="BANNER"
-        ads:adUnitId="@string/admob_banner_unit_id"/>
+        ads:adUnitId="@string/admob_banner_unit_id_for_test"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/close_app_dialog.xml
+++ b/app/src/main/res/layout/close_app_dialog.xml
@@ -24,7 +24,7 @@
         android:id="@+id/close_dialog_ad"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        ads:adUnitId="@string/admob_ad_unit_id"
+        ads:adUnitId="@string/admob_ad_unit_id_for_test"
         app:gnt_template_type="@layout/gnt_medium_template_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_alarm_setting.xml
+++ b/app/src/main/res/layout/fragment_alarm_setting.xml
@@ -168,6 +168,7 @@
 
             <SeekBar
                 android:id="@+id/volume_bar"
+                android:max="15"
                 android:layout_width="200dp"
                 android:layout_height="match_parent"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="pref_status_bar_notification_summary">상단바에 다음 알람시간을 표시합니다.</string>
     <string name="pref_disturb_mode_title">방해금지모드에서도 알람 허용</string>
     <string name="pref_disturb_mode_summary">방해금지모드에서도 알람이 울립니다</string>
+    <string name="pref_always_max_volume_title">언제나 최대 볼륨</string>
+    <string name="pref_always_max_volume_summary">알람이 항상 최대 볼륨으로 울립니다</string>
     <string name="pref_onboarding_title">AR 도움말 다시보기</string>
     <string name="pref_app_info_title">앱 정보</string>
 

--- a/app/src/main/res/xml/preferences_setting.xml
+++ b/app/src/main/res/xml/preferences_setting.xml
@@ -6,14 +6,17 @@
         <SwitchPreference
             app:key="pref_status_bar_notification"
             app:title="@string/pref_status_bar_notification_title"
-            app:summary="@string/pref_status_bar_notification_summary"
-            app:useSimpleSummaryProvider="true" />
+            app:summary="@string/pref_status_bar_notification_summary"/>
+
+        <SwitchPreference
+            app:key="pref_always_max_volume"
+            app:title="@string/pref_always_max_volume_title"
+            app:summary="@string/pref_always_max_volume_summary"/>
 
         <Preference
             app:key="pref_disturb_mode"
             app:title="@string/pref_disturb_mode_title"
-            app:summary="@string/pref_disturb_mode_summary"
-            app:useSimpleSummaryProvider="true" />
+            app:summary="@string/pref_disturb_mode_summary"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
## #10 버그 수정
- AlarmService에서 AudioManger를 통해 media volume을 설정한 알람의 값으로 초기화
- media volume은 [0, 15] 값이기 때문에 AlarmSettingFragment의 seekbar 최대 값을 15로 수정

## #11 '언제나 최대 볼륨' Configuration 구현
- SwtichPreference의 on/off를 sharedPreference를 통해 저장
- 기존에 sharedPreference의 name이 "notifyPref"로 이상했음 -> configrationPreference로 변경
- configuration preference 항목이 늘어날 것을 고려, 기존 onPreferenceTreeClick( )을 보다 재사용성 좋게 만듦
